### PR TITLE
deploy nits from map redeploy 

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM datajoint/jupyter:python3.6
 # for production builds
 ADD . /src/mapapi
 
-RUN pip install --upgrade --pre datajoint
+RUN pip install --upgrade datajoint
 
 RUN \
     pip install -e /src/mapapi && \

--- a/map-frontend/Dockerfile.dev
+++ b/map-frontend/Dockerfile.dev
@@ -21,4 +21,4 @@ HEALTHCHECK       \
         curl --fail http://localhost:9000 || exit 1
 WORKDIR /frontend
 
-CMD ["ng","serve","--host","0.0.0.0","--port","9000"]
+CMD ["ng","serve","--host","0.0.0.0","--port","9000", "--disable-host-check"]


### PR DESCRIPTION
* disable --pre in backend Dockerfile - this now points to datajoint 13.x which needs more fixes before regression tests
* add --disable-host-check in frontend Dockerfile.dev - allows use in production with virtual hosts, shouldn't impact other use